### PR TITLE
Allow genre field and integer difficulty in song-sheets schema

### DIFF
--- a/schemas/song-sheets.json
+++ b/schemas/song-sheets.json
@@ -60,8 +60,8 @@
           },
           "difficulty": {
             "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+$",
-            "description": "Difficulty rating as decimal string"
+            "pattern": "^[0-9]+(\\.[0-9]+)?$",
+            "description": "Difficulty rating as a numeric string, optionally with a decimal part"
           },
           "duration": {
             "type": "string",
@@ -76,6 +76,10 @@
           "language": {
             "type": "string",
             "description": "Language of the song lyrics"
+          },
+          "genre": {
+            "type": "string",
+            "description": "Comma-separated list of genres for the song"
           },
           "source": {
             "type": "string",


### PR DESCRIPTION
## Summary

Fixes the failing `song-sheets` dataset validation seen in [this CI run](https://github.com/UkuleleTuesday/datasets/actions/runs/27754290550/job/82112182184), which reported 7 validation errors.

Two schema changes in `schemas/song-sheets.json`:

1. **Add a `genre` property** — several items (e.g. The Chieftains, Bruce Springsteen, Donna Summer, Manu Chao, Vance Joy) carry a comma-separated `genre` value that the schema rejected via `additionalProperties: false`.
2. **Relax the `difficulty` pattern** from `^[0-9]+\.[0-9]+$` to `^[0-9]+(\.[0-9]+)?$` so bare integers like `"3"` (Nancy Boy) and `"2"` (Blinding Lights) are accepted alongside decimals.

## Testing

- Ran the validator against the previously-failing cases (genre + integer difficulty) — now passes.
- `test_validation.py` suite passes (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9rMGiLDQfUtgdAPwzEPMg)_